### PR TITLE
Remove unnecessary UKF constructor method

### DIFF
--- a/src/UnscentedKalmanFilterAdditive.jl
+++ b/src/UnscentedKalmanFilterAdditive.jl
@@ -14,11 +14,6 @@ type AdditiveNonLinUKFSSM{T} <: AbstractSSM
 	W::Matrix{T} # Observation covariance
 end
 
-function AdditiveNonLinUKFSSM{T}(f::Function, V::Matrix{T},
-		g::Function, W::Matrix{T})
-    return AdditiveNonLinUKFSSM{T}(f, V, g, W)
-end
-
 """
 Data structure containing the parameters required to place the sigma points for the Unscented Kalman Filter
 


### PR DESCRIPTION
This should remove the 2nd warning that is referred to in [issue #11](https://github.com/ElOceanografo/StateSpace.jl/issues/11).  
